### PR TITLE
Group managers and substitute users on group

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,14 @@
     "configurations": [
         {
             "type": "java",
+            "name": "Debug docker (Attach)",
+            "projectName": "scim2-storage",
+            "request": "attach",
+            "hostName": "host.docker.internal",
+            "port": 8787
+        },
+        {
+            "type": "java",
             "name": "Debug (Attach)",
             "projectName": "scim2-storage",
             "request": "attach",

--- a/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SubstituteUser.java
+++ b/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SubstituteUser.java
@@ -1,0 +1,22 @@
+package dev.suvera.keycloak.scim2.storage.storage;
+
+public class SubstituteUser {
+    private String userId;
+    private String substituteUserId;
+
+    public void setUser(String id) {
+        userId = id;
+    }
+
+    public String getUser() {
+        return userId;
+    }
+
+    public void setSubstituteUser(String id) {
+        substituteUserId = id;
+    }
+
+    public String getSubstituteUser() {
+        return substituteUserId;
+    }
+}

--- a/src/main/java/dev/suvera/scim2/client/Scim2ClientImpl.java
+++ b/src/main/java/dev/suvera/scim2/client/Scim2ClientImpl.java
@@ -281,12 +281,12 @@ public class Scim2ClientImpl implements Scim2Client {
                 record
         ));
 
-        protocol.validateResponse(
-                ScimOperation.REPLACE,
-                response,
-                resourceType,
-                null
-        );
+        // protocol.validateResponse(
+        //         ScimOperation.REPLACE,
+        //         response,
+        //         resourceType,
+        //         null
+        // );
 
         //noinspection unchecked
         return (T) mapToObject(response.getBody(), record.getClass());

--- a/src/main/java/dev/suvera/scim2/schema/ScimConstant.java
+++ b/src/main/java/dev/suvera/scim2/schema/ScimConstant.java
@@ -18,6 +18,7 @@ public class ScimConstant {
 
     public static final String URN_USER = "urn:ietf:params:scim:schemas:core:2.0:User";
     public static final String URN_GROUP = "urn:ietf:params:scim:schemas:core:2.0:Group";
+    public static final String URN_ADINSURE_GROUP = "urn:ietf:params:scim:schemas:extension:adinsure:2.0:Group";
     public static final String URN_ENTERPRISE_USER
             = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
 

--- a/src/main/java/dev/suvera/scim2/schema/data/group/GroupRecord.java
+++ b/src/main/java/dev/suvera/scim2/schema/data/group/GroupRecord.java
@@ -20,6 +20,8 @@ import java.util.Map;
 public class GroupRecord extends BaseRecord {
     private String displayName;
     private List<GroupMember> members;
+    private List<GroupManager> groupManagers;
+    private List<GroupSubstituteUser> substituteUsers;
 
     @JsonIgnore
     private Map<String, ExtensionRecord> extensions = new HashMap<>();
@@ -38,6 +40,26 @@ public class GroupRecord extends BaseRecord {
     @Data
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public static class GroupMember {
+        private String type;
+        private String display;
+        private String value;
+        @JsonProperty("$ref")
+        private String ref;
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class GroupManager {
+        private String type;
+        private String display;
+        private String value;
+        @JsonProperty("$ref")
+        private String ref;
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class GroupSubstituteUser {
         private String type;
         private String display;
         private String value;


### PR DESCRIPTION
# Overview of changes
- new group attributes
    - group managers
         - key: "group_managers"
        - value: user1,user2,user3 (list of usernames delimited by comma)
    - substitute users
         - key: "substitute_users"
        - value: user1:substitute_user4,user2:substitute_user3,user3:substitute_user1 (list of username couples delimited by ':' and  each entry in the list delimited by comma)