### PR TITLE
user create job executed with delay to allow user to be updated with all available data

### DIFF
--- a/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SkssStorageProvider.java
+++ b/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SkssStorageProvider.java
@@ -54,7 +54,7 @@ public class SkssStorageProvider implements UserStorageProvider, UserRegistratio
     public UserModel addUser(RealmModel realmModel, String username) {
         UserModel localUser = createAdapter(realmModel, username);
 
-        jobQueue.enqueueUserCreateJob(realmModel, model, localUser);
+        jobQueue.enqueueUserCreateJob(realmModel, model, localUser.getId());
 
         return localUser;
     }

--- a/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SkssStorageProviderFactory.java
+++ b/src/main/java/dev/suvera/keycloak/scim2/storage/storage/SkssStorageProviderFactory.java
@@ -74,7 +74,7 @@ public class SkssStorageProviderFactory implements UserStorageProviderFactory<Sk
                 .add()
 
                 .property()
-                .label("Version: " + SkssStorageProviderFactory.class.getPackage().getImplementationVersion() + "-12")
+                .label("Version: " + SkssStorageProviderFactory.class.getPackage().getImplementationVersion() + "-13")
                 .helpText("Plugin version")
                 .add()
 


### PR DESCRIPTION
When a user is created only username is available in storage provider with other information added later in the flow. To allow the user to populate itself a delay was added to the add user job so that the complete user is sent to SCIM server. The delay currently fixed to half a second.