### PR TITLE
Federation link is not parsed from event data anymore

### DIFF
--- a/src/main/java/dev/suvera/keycloak/scim2/storage/events/ScimEventListener.java
+++ b/src/main/java/dev/suvera/keycloak/scim2/storage/events/ScimEventListener.java
@@ -69,13 +69,12 @@ public class ScimEventListener implements EventListenerProvider {
 
             if (representationJson != null) {
                 JsonNode usernameNode = representationJson.get("username");
-                JsonNode federationLinkNode = representationJson.get("federationLink");
 
                 if (userId != null) {
                     if (operationType == OperationType.CREATE && usernameNode != null) {
                         jobQueue.enqueueUserCreateJobByUsername(event.getRealmId(), usernameNode.asText());
-                    } else if (operationType == OperationType.UPDATE && federationLinkNode != null) {
-                        jobQueue.enqueueUserCreateJob(event.getRealmId(), federationLinkNode.asText(), userId);
+                    } else if (operationType == OperationType.UPDATE) {
+                        jobQueue.enqueueUserCreateJob(event.getRealmId(), userId);
                     }
                 }
             }

--- a/src/test/java/dev/suvera/helpers/FluentTestsHelperWithUserUpdate.java
+++ b/src/test/java/dev/suvera/helpers/FluentTestsHelperWithUserUpdate.java
@@ -1,0 +1,25 @@
+package dev.suvera.helpers;
+
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.test.FluentTestsHelper;
+
+public class FluentTestsHelperWithUserUpdate extends FluentTestsHelper {
+    public FluentTestsHelperWithUserUpdate(String keycloakBaseUrl, String adminUserName, String adminPassword, String adminRealm, String adminClient, String testRealm) {
+        super(keycloakBaseUrl, adminUserName, adminPassword, adminRealm, adminClient, testRealm);
+    }
+
+    @Override
+    public FluentTestsHelperWithUserUpdate init() {
+        super.init();
+        return this;
+    }
+
+    public FluentTestsHelperWithUserUpdate updateUserEmail(String userName, String email) {
+        assert isInitialized;
+        UserRepresentation userRepresentation = keycloak.realms().realm(testRealm).users().search(userName).get(0);
+        userRepresentation.setEmail(email);
+        keycloak.realms().realm(testRealm).users().get(userRepresentation.getId()).update(userRepresentation);
+        return this;
+    }
+}


### PR DESCRIPTION
Due to differences in event data for different Keycloak versions (see this issue: https://github.com/keycloak/keycloak/issues/14704) the federation link is not parsed from event anymore. It is retrieved later when sync job is executed.

Added integration test that triggers user update event.